### PR TITLE
feat(calendar): show multi-day tasks

### DIFF
--- a/components/calendar/CustomCalendar.tsx
+++ b/components/calendar/CustomCalendar.tsx
@@ -103,7 +103,11 @@ export default function CustomCalendar({ onEdit, userEmail }: Props) {
 
   const detailTasks = useMemo(() => {
     if (!selectedDate) return [];
-    return tasks.filter((t) => t.due_date?.slice(0, 10) === selectedDate);
+    return tasks.filter((t) => {
+      const start = t.due_date?.slice(0, 10);
+      const end = (t.deadline_date || t.due_date)?.slice(0, 10);
+      return start && start <= selectedDate && selectedDate <= end;
+    });
   }, [tasks, selectedDate]);
 
   const detailEvents = groupedEvents[selectedDate] || [];


### PR DESCRIPTION
## Summary
- account for deadline ranges when counting tasks per day
- show tasks in day details if selected date is within task range

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Missing Supabase env variables)*

------
https://chatgpt.com/codex/tasks/task_e_688f8edbbfb483259d3bb18c814597b3